### PR TITLE
Force ESLint directives to be comment

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,7 @@
     "browser": true,
     "es2021": true
   },
-  "extends": ["plugin:react/recommended"],
+  "extends": ["plugin:react/recommended", "plugin:eslint-comments/recommended"],
   "overrides": [
     {
       "files": ["*.test.*"],
@@ -31,6 +31,7 @@
     }
   },
   "rules": {
+    "eslint-comments/require-description": "error",
     "@typescript-eslint/adjacent-overload-signatures": "error",
     "@typescript-eslint/array-type": [
       "warn",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,7 +31,10 @@
     }
   },
   "rules": {
-    "eslint-comments/require-description": "error",
+    "eslint-comments/require-description": [
+      "error",
+      {"ignore": ["eslint-enable"]}
+    ],
     "@typescript-eslint/adjacent-overload-signatures": "error",
     "@typescript-eslint/array-type": [
       "warn",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/react": "^18.0.24",
         "@types/react-dom": "^18.0.8",
         "env-cmd": "^10.1.0",
+        "eslint-plugin-eslint-comments": "^3.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
@@ -7316,6 +7317,24 @@
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-eslint-comments": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
+      "integrity": "sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5",
+        "ignore": "^5.0.5"
+      },
+      "engines": {
+        "node": ">=6.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=4.19.1"
       }
     },
     "node_modules/eslint-plugin-flowtype": {
@@ -22932,6 +22951,15 @@
             "ms": "^2.1.1"
           }
         }
+      }
+    },
+    "eslint-plugin-eslint-comments": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
+      "integrity": "sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==",
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "ignore": "^5.0.5"
       }
     },
     "eslint-plugin-flowtype": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^18.0.24",
     "@types/react-dom": "^18.0.8",
     "env-cmd": "^10.1.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/src/Scripts/reportWebVitals.ts
+++ b/src/Scripts/reportWebVitals.ts
@@ -16,16 +16,15 @@ function ReportWebVitals(on_perf_entry?: ReportHandler): void {
         getLCP: get_lcp,
         getTTFB: get_ttfb,
       }: Readonly<{
-        // the names cannot be redefined
-        // eslint-disable-next-line @typescript-eslint/naming-convention
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- the names cannot be redefined
         getCLS: Handler;
-        // eslint-disable-next-line @typescript-eslint/naming-convention
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- the names cannot be redefined
         getFCP: Handler;
-        // eslint-disable-next-line @typescript-eslint/naming-convention
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- the names cannot be redefined
         getFID: Handler;
-        // eslint-disable-next-line @typescript-eslint/naming-convention
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- the names cannot be redefined
         getLCP: Handler;
-        // eslint-disable-next-line @typescript-eslint/naming-convention
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- the names cannot be redefined
         getTTFB: Handler;
       }>) => {
         get_cls(on_perf_entry);


### PR DESCRIPTION
## Description

A new ESLint plugin [`eslint-plugin-eslint-comments`](https://www.npmjs.com/package/eslint-plugin-eslint-comments) is now available. This plugin hold `eslint-comments/require-description` rule, which force to comment use of ESLint directives.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested on my local development environment. It works properly, five uncomment directives were found by rule in `reportWebVitals.ts` file. 

## Particularity ❗ 

@galyfray can you take a look on `reportWebVitals.ts` file and comment directives ? 