### PR TITLE
[BUG]Hot fixes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,6 +42,29 @@
     ],
     "@typescript-eslint/await-thenable": "error",
     "@typescript-eslint/ban-ts-comment": "error",
+    "@typescript-eslint/ban-types": [
+      "error",
+      {
+        "types": {
+          "object": {
+            "message": "In TS object mean any JS object. This type is way too broad, consider narrowing it down."
+          },
+          "Function": {
+            "message": "The Function type is too braod. Using this type will cause you trouble with readonly.",
+            "fixWith": "()=>void"
+          },
+          "CallableFunction": {
+            "message": "The CallableFunction type is too braod. Using this type will cause you trouble with readonly.",
+            "fixWith": "()=>void"
+          },
+          "NewableFunction": {
+            "message": "The NewableFunction type is too braod. Using this type will cause you trouble with readonly.",
+            "fixWith": "()=>void"
+          }
+        },
+        "extendDefaults": true
+      }
+    ],
     "@typescript-eslint/class-literal-property-style": "warn",
     "@typescript-eslint/consistent-generic-constructors": "warn",
     "@typescript-eslint/consistent-indexed-object-style": "warn",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -243,6 +243,7 @@
     "@typescript-eslint/dot-notation": "warn",
     "@typescript-eslint/no-dupe-class-members": "warn",
     "@typescript-eslint/no-empty-function": "error",
+    "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/no-implied-eval": "error",
     "@typescript-eslint/no-invalid-this": "warn",
     "@typescript-eslint/no-loop-func": "warn",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,7 +48,10 @@
     "@typescript-eslint/consistent-type-assertions": "warn",
     "@typescript-eslint/consistent-type-definitions": "warn",
     "@typescript-eslint/consistent-type-exports": "warn",
-    "@typescript-eslint/consistent-type-imports": "warn",
+    "@typescript-eslint/consistent-type-imports": [
+      "warn",
+      {"fixStyle": "inline-type-imports"}
+    ],
     "@typescript-eslint/explicit-function-return-type": "warn",
     "@typescript-eslint/explicit-member-accessibility": "warn",
     "@typescript-eslint/explicit-module-boundary-types": "warn",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -60,6 +60,10 @@
           "NewableFunction": {
             "message": "The NewableFunction type is too braod. Using this type will cause you trouble with readonly.",
             "fixWith": "()=>void"
+          },
+          "any": {
+            "message": "The any type is unsafe and too broad. Consider using a more constrained type if possible.",
+            "fixWith": "unknown"
           }
         },
         "extendDefaults": true
@@ -266,7 +270,6 @@
     "@typescript-eslint/dot-notation": "warn",
     "@typescript-eslint/no-dupe-class-members": "warn",
     "@typescript-eslint/no-empty-function": "error",
-    "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/no-implied-eval": "error",
     "@typescript-eslint/no-invalid-this": "warn",
     "@typescript-eslint/no-loop-func": "warn",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -70,7 +70,7 @@
         "leadingUnderscore": "forbid",
         "trailingUnderscore": "forbid",
         "types": ["boolean"],
-        "prefix": ["IS_", "is_"]
+        "prefix": ["IS_", "is"]
       },
       {
         "selector": ["variable"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "strictBindCallApply": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## 1) Description

Fixed #5 
Fixed #22 
Resolves #28 
Resolves #29 
Added the `strictBindCallApply` flag to the TS compiler.

## 2) Technical choice

I banned several types as long as the `Function` one. Mostly derivatives from this type that have no real use cases unless you are working on the compiler. The `object` type has been banned as well, since this type is really permissive. 

The `any` type as been banned through the usage of the [`@typescript-eslint/ban-types`](https://typescript-eslint.io/rules/ban-types/) rule, as it allowed to propose a quick fix. The fix suggested is the usage of the unknown type, which is almost the same as the `any` but with type safety.  This decision has been made to allow the developers to use a bit of logic when casting objects to a proper type.

## 3) Checks

- [x] My code follows the contributing guidelines
- [x] I have read the code of conduct
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes