### PR TITLE
[REFACTOR] ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -255,7 +255,10 @@
     ],
     "@typescript-eslint/prefer-optional-chain": "warn",
     "@typescript-eslint/prefer-readonly": "warn",
-    "@typescript-eslint/prefer-readonly-parameter-types": "warn",
+    "@typescript-eslint/prefer-readonly-parameter-types": [
+      "warn",
+      {"ignoreInferredTypes": true}
+    ],
     "@typescript-eslint/prefer-reduce-type-parameter": "warn",
     "@typescript-eslint/prefer-return-this-type": "warn",
     "@typescript-eslint/prefer-string-starts-ends-with": "warn",
@@ -264,6 +267,10 @@
     "@typescript-eslint/restrict-template-expressions": "error",
     "@typescript-eslint/sort-type-constituents": "warn",
     "@typescript-eslint/strict-boolean-expressions": "warn",
+    "@typescript-eslint/typedef": [
+      "warn",
+      {"variableDeclaration": true, "variableDeclarationIgnoreFunction": true}
+    ],
     "@typescript-eslint/unbound-method": "error",
     "@typescript-eslint/unified-signatures": "warn",
     "@typescript-eslint/default-param-last": "warn",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "sass": "^1.56.1"
   },
   "lint-staged": {
-    "*.{ts,tsx}": "eslint --cache --fix",
     "*.{md,ts,tsx,json,html}": "prettier --write"
   }
 }


### PR DESCRIPTION
## 1) Description
- Resolves #31 

Removed ESLint from the pre commit hooks. It was a bad idea as it prevent from committing if there is a problem.
Made typing mandatory when assigning to a variable. Note that variables that hold functions are not concerned by this.
When the types are inferred, it is now possible to let the parameters non-read-only. 

## 2) Checks

- [x] My code follows the contributing guidelines
- [x] I have read the code of conduct
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes