### PR TITLE
[REFACTOR] tweaked an ESLint rule and a workflow

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -296,7 +296,7 @@
     "@typescript-eslint/no-use-before-define": "warn",
     "@typescript-eslint/no-useless-constructor": "warn",
     "@typescript-eslint/require-await": "error",
-    "@typescript-eslint/return-await": "warn",
+    "@typescript-eslint/return-await": ["warn", "always"],
 
     "array-callback-return": ["error", {"checkForEach": true}],
     "constructor-super": "error",

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,8 +33,9 @@ jobs:
       with:
         report-only-changed-files: true
         coverage-path: ./coverage.txt
+    - name: Fixing Jest
     # Jest does exit with a 0 exit code even if the tests fails
-    - run: |
+      run: |
         if [ ${{steps.coverage.outputs.lines}} -eq 0 ]; then
           exit 1;
         fi

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,3 +33,8 @@ jobs:
       with:
         report-only-changed-files: true
         coverage-path: ./coverage.txt
+    # Jest does exit with a 0 exit code even if the tests fails
+    - run: |
+        if [ ${{steps.coverage.outputs.lines}} -eq 0 ]; then
+          exit 1;
+        fi


### PR DESCRIPTION
## 1) Description

Changed the ESLint rule that prevented the dev from returning an awaited promise to require it. Awaiting a promise before returning it might seem useless, but it helps with the stack trace being more precise. This makes debugging easier.

Jest might return with an exit code of 0 even if some tests failed. This behavior only exhibits on GH's action system, making it incredibly hard to find. I added a bit of code to make the workflows fails if a test fails.

## 2) Technical choice

I used an output from the reporter action. This output is computed from the output of jest, thus avoiding parsing it ourselves. 

## 3) Checks

- [X] My code follows the contributing guidelines
- [X] I have read the code of conduct
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes