### PR TITLE
[REFACTOR] : Added `has` boolean prefix eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -140,7 +140,7 @@
         "format": ["UPPER_CASE"],
         "modifiers": ["const"],
         "types": ["boolean"],
-        "prefix": ["IS_"],
+        "prefix": ["IS_", "HAS_"],
         "leadingUnderscore": "forbid",
         "trailingUnderscore": "forbid"
       },
@@ -162,7 +162,7 @@
         "format": ["UPPER_CASE"],
         "modifiers": ["readonly"],
         "types": ["boolean"],
-        "prefix": ["IS_"],
+        "prefix": ["IS_", "HAS_"],
         "leadingUnderscore": "forbid",
         "trailingUnderscore": "forbid"
       },
@@ -188,7 +188,7 @@
         ],
         "format": ["PascalCase"],
         "types": ["boolean"],
-        "prefix": ["is"],
+        "prefix": ["is", "has"],
         "leadingUnderscore": "forbid",
         "trailingUnderscore": "forbid"
       },
@@ -202,7 +202,7 @@
         "selector": ["parameter", "variable"],
         "format": ["snake_case"],
         "types": ["boolean"],
-        "prefix": ["is_"],
+        "prefix": ["is_", "has_"],
         "leadingUnderscore": "forbid",
         "trailingUnderscore": "forbid"
       },

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -98,7 +98,7 @@
         "leadingUnderscore": "forbid",
         "trailingUnderscore": "forbid",
         "types": ["boolean"],
-        "prefix": ["IS_", "is"]
+        "prefix": ["IS_", "is", "HAS_", "has"]
       },
       {
         "selector": [


### PR DESCRIPTION
## 1) Description

As requested in #57, I added `has` and `HAS_` as prefix for boolean in eslint config.

## 2) Technical choice

I could have added more prefixes like `would` but the list would effectively be infinite. `is` and `has` cover the vast majority of cases.

## 3) Checks

- [x] My code follows the contributing guidelines
- [x] I have read the code of conduct
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes